### PR TITLE
Feat: switch to `pyenv` and `pyenv-virtualenv`

### DIFF
--- a/roles/ZSH/files/.zshrc
+++ b/roles/ZSH/files/.zshrc
@@ -144,8 +144,6 @@ plugins=(
     pip
     rsync
     tmux
-    virtualenv
-    virtualenvwrapper
     zsh-autosuggestions
     zsh-completions
     zshmarks
@@ -208,13 +206,10 @@ export NVM_DIR="${HOME}/.nvm"
 # Python, pyenv, and virtualenv
 command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
+pyenv virtualenvwrapper
 
+export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"
 export WORKON_HOME=${HOME}/.venvs
 export VIRTUAL_ENV_DISABLE_PROMPT=
-export VIRTUALENVWRAPPER_PYTHON=$(which python3)
-export VIRTUALENV_PYTHON=$(which python3.8 || which python3)
-if [[ -f "/usr/local/bin/virtualenvwrapper.sh" ]]; then
-    . /usr/local/bin/virtualenvwrapper.sh
-fi
 
 # vim: set filetype=zsh : 

--- a/roles/ZSH/files/.zshrc
+++ b/roles/ZSH/files/.zshrc
@@ -205,7 +205,10 @@ unset -f check_zsh_theme
 export NVM_DIR="${HOME}/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 
-# Python and virtualenv
+# Python, pyenv, and virtualenv
+command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+
 export WORKON_HOME=${HOME}/.venvs
 export VIRTUAL_ENV_DISABLE_PROMPT=
 export VIRTUALENVWRAPPER_PYTHON=$(which python3)

--- a/roles/ZSH/files/zsh_darwin
+++ b/roles/ZSH/files/zsh_darwin
@@ -17,6 +17,8 @@ done
 # Add custom plugins
 plugins+=(brew)
 
+# from https://github.com/pyenv/pyenv#homebrew-in-macos
+alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 alias brew-update='brew update && brew upgrade && brew cleanup'
 
 # vim: set filetype=zsh : 

--- a/roles/ZSH/files/zsh_darwin
+++ b/roles/ZSH/files/zsh_darwin
@@ -14,6 +14,9 @@ for python_dir in $(brew --prefix)/opt/python@*; do
 	export PATH="${python_dir}/bin:${PATH}"
 done
 
+# for https://github.com/pyenv/pyenv-virtualenv
+eval "$(pyenv virtualenv-init -)"
+
 # Add custom plugins
 plugins+=(brew)
 

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -42,6 +42,9 @@
     ]
     state: present
 
+- name: install python versions
+  command: pyenv install 3.8
+
 - name: python virtualenvwrapper
   become: yes
   pip:

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -15,6 +15,8 @@
       'neofetch',
       'neovim',
       'pyenv',
+      'pyenv-virtualenv',
+      'pyenv-virtualenvwrapper',
       'python',
       'ranger',
       'rsync',
@@ -44,15 +46,6 @@
 
 - name: install python versions
   command: pyenv install 3.8.13
-
-- name: python virtualenvwrapper
-  become: yes
-  pip:
-    name: "{{ item }}"
-    executable: "{{ pip3_bin }}"
-  loop:
-    - virtualenv
-    - virtualenvwrapper
 
 - name: create temporary directory for powerline fonts
   tempfile: state=directory suffix=powerline-fonts

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -14,6 +14,7 @@
       'htop',
       'neofetch',
       'neovim',
+      'pyenv',
       'python',
       'ranger',
       'rsync',
@@ -23,6 +24,13 @@
       'watch',
       'wget',
       'zsh',
+      # pyenv-requirements:
+      'openssl',
+      'readline',
+      'sqlite3',
+      'xz',
+      'zlib',
+      'tcl-tk'
     ]
     state: present
 

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -15,7 +15,6 @@
       'neofetch',
       'neovim',
       'python',
-      'python@3.8',
       'ranger',
       'rsync',
       'rename',

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -43,7 +43,7 @@
     state: present
 
 - name: install python versions
-  command: pyenv install 3.8
+  command: pyenv install 3.8.13
 
 - name: python virtualenvwrapper
   become: yes

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -47,6 +47,9 @@
 - name: install python versions
   command: pyenv install -s 3.8.13
 
+- name: set 3.8.13 as the global pyenv version
+  command: pyenv global 3.8.13
+
 - name: create temporary directory for powerline fonts
   tempfile: state=directory suffix=powerline-fonts
   register: powerline_dir

--- a/roles/packages/tasks/macosx/main.yml
+++ b/roles/packages/tasks/macosx/main.yml
@@ -45,7 +45,7 @@
     state: present
 
 - name: install python versions
-  command: pyenv install 3.8.13
+  command: pyenv install -s 3.8.13
 
 - name: create temporary directory for powerline fonts
   tempfile: state=directory suffix=powerline-fonts


### PR DESCRIPTION
This only ports the setup for macOS. Using:
- [`pyenv`](https://github.com/pyenv/pyenv)
- [`pyenv-virtualenv`](https://github.com/pyenv/pyenv-virtualenv)
- [`pyenv-virtualenvwrapper`](https://github.com/pyenv/pyenv-virtualenvwrapper)